### PR TITLE
Add version to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "knockout-observable-dictionary",
+  "version": "0.0.0",
   "devDependencies": {
     "grunt": "~0",
     "grunt-contrib-clean": "~0",


### PR DESCRIPTION
Fixes downloading this via npm, on recent npm versions.
Like this:
http://stackoverflow.com/questions/26538658/error-when-running-npm-install-could-not-install-error-no-version-provided
